### PR TITLE
helm 2.9.1, add git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 env:
   DOCKER_IMAGE=dtzar/helm-kubectl
-  DOCKER_TAG=2.9.0
+  DOCKER_TAG=2.9.1
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 ENV KUBE_LATEST_VERSION="v1.10.2"
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.9.0"
+ENV HELM_VERSION="v2.9.1"
 
-RUN apk add --no-cache ca-certificates bash \
+RUN apk add --no-cache ca-certificates bash git \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q http://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 Supported tags and release links
 
+* [2.9.1](https://github.com/dtzar/helm-kubectl/releases/tag/2.9.1) - helm v2.9.1, kubectl v1.10.2, alpine 3.7
 * [2.9.0](https://github.com/dtzar/helm-kubectl/releases/tag/2.9.0) - helm v2.9.0, kubectl v1.10.2, alpine 3.7
 * [2.8.2](https://github.com/dtzar/helm-kubectl/releases/tag/2.8.2) - helm v2.8.2, kubectl v1.9.4, alpine 3.7
 * [2.8.1](https://github.com/dtzar/helm-kubectl/releases/tag/2.8.1) - helm v2.8.1, kubectl v1.9.2, alpine 3.7
@@ -27,7 +28,7 @@ Supported tags and release links
 
 ## Overview
 
-This lightweight alpine docker image provides kubectl and helm binaries for working with a Kubernetes cluster.  A local configured kubectl is a prerequisite to use helm per [helm documentation](https://github.com/kubernetes/helm/blob/master/docs/quickstart.md).  This image is useful for general helm administration such as deploying helm charts and managing releases. It is also perfect for any automated deployment pipeline needing to use helm which supports docker images such as [Concourse CI](https://concourse.ci), [Jenkins on Kubernetes](https://kubeapps.com/charts/stable/jenkins), [Travis CI](https://docs.travis-ci.com/user/docker/), and [Circle CI](https://circleci.com/integrations/docker/).  Having bash installed allows for better support for troubleshooting by being able to exec / terminal in and run desired shell scripts.
+This lightweight alpine docker image provides kubectl and helm binaries for working with a Kubernetes cluster.  A local configured kubectl is a prerequisite to use helm per [helm documentation](https://github.com/kubernetes/helm/blob/master/docs/quickstart.md).  This image is useful for general helm administration such as deploying helm charts and managing releases. It is also perfect for any automated deployment pipeline needing to use helm which supports docker images such as [Concourse CI](https://concourse.ci), [Jenkins on Kubernetes](https://kubeapps.com/charts/stable/jenkins), [Travis CI](https://docs.travis-ci.com/user/docker/), and [Circle CI](https://circleci.com/integrations/docker/).  Having bash installed allows for better support for troubleshooting by being able to exec / terminal in and run desired shell scripts.  Git installed allows installation of [helm plugins](https://github.com/kubernetes/helm/blob/master/docs/plugins.md).
 
 If it is desired to only use kubectl and have kubectl as the entry command (versus this image as bash entry command), I recommend checking out this image instead:
 [lachlanevenson/kubectl](https://hub.docker.com/r/lachlanevenson/k8s-kubectl/)


### PR DESCRIPTION
- helm 2.9.1
- alpine 3.7
- kubectl 1.10.2
- NEW adds git support to allow helm plugin installs, fixes #16 