### PR TITLE
add jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV KUBE_LATEST_VERSION="v1.14.1"
 # https://github.com/kubernetes/helm/releases
 ENV HELM_VERSION="v2.14.0"
 
-RUN apk add --no-cache ca-certificates bash git openssh curl \
+RUN apk add --no-cache ca-certificates bash git openssh curl jq \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://storage.googleapis.com/kubernetes-helm/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \


### PR DESCRIPTION
Hi, would you consider adding `jq` to the image?

I understand if you don't want to bloat the image, but I found `jq` pretty useful when working with `helm` outputs.

My specific use case is: 
get the current deployed setting of a value conditionally

Using `jq` inside the build script, I can decide on which version to deploy:
```sh
if [ ${params.buildVarnish} = true ]; then
  HELM_TAG_VARNISH="${params.dockerImageTag}"
else
  HELM_TAG_VARNISH=`helm get values my-release --output json | jq -r '.varnish.tag'`
fi

helm upgrade my-release my-chart \
  --set-string nginx.tag=${HELM_TAG_NGINX},varnish.tag=${HELM_TAG_VARNISH}
```
