### PR TITLE
File permissions for OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,10 @@ RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && chmod +x /usr/local/bin/helm
+    && chmod +x /usr/local/bin/helm \
+    && chmod g+rwx /root \
+    && mkdir /config \
+    && chmod g+rwx /config    
 
 WORKDIR /config
 


### PR DESCRIPTION
- Sets /root and /config permissions to `rwx` for the group

Fixes #59