### PR TITLE
Support for Helm 3.4.0 and k8s 1.19.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 env:
   DOCKER_IMAGE=dtzar/helm-kubectl
-  DOCKER_TAG=3.3.4
+  DOCKER_TAG=3.4.0
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-ENV KUBE_LATEST_VERSION="v1.19.2"
+ENV KUBE_LATEST_VERSION="v1.19.3"
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
 ENV HELM_VERSION="v3.4.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -15,7 +15,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 ENV KUBE_LATEST_VERSION="v1.19.2"
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.3.4"
+ENV HELM_VERSION="v3.4.0"
 
 RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.4.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.0) - helm v3.4.0, kubectl v1.19.2, alpine 3.12
 * [3.3.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.4) - helm v3.3.4, kubectl v1.19.2, alpine 3.12
 * [3.3.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.1) - helm v3.3.1, kubectl v1.18.8, alpine 3.12
 * [3.3.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.0) - helm v3.3.0, kubectl v1.18.6, alpine 3.12

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Supported tags and release links
 
-* [3.4.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.0) - helm v3.4.0, kubectl v1.19.2, alpine 3.12
+* [3.4.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.0) - helm v3.4.0, kubectl v1.19.3, alpine 3.12
 * [3.3.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.4) - helm v3.3.4, kubectl v1.19.2, alpine 3.12
 * [3.3.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.1) - helm v3.3.1, kubectl v1.18.8, alpine 3.12
 * [3.3.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.0) - helm v3.3.0, kubectl v1.18.6, alpine 3.12


### PR DESCRIPTION
* Added support for Helm 3.4.0 that was released today.