### PR TITLE
added support for helm 2.17.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 
 env:
   DOCKER_IMAGE=dtzar/helm-kubectl
-  DOCKER_TAG=2.16.1
+  DOCKER_TAG=2.17.0
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ sudo: required
 env:
   DOCKER_IMAGE=dtzar/helm-kubectl
   DOCKER_TAG=2.17.0
+  TAG_LATEST=false
 
 services:
   - docker
 
 script:
   - docker build --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $DOCKER_IMAGE:$DOCKER_TAG .
-  - docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest
+  - if $TAG_LATEST ; then docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest; else docker tag $DOCKER_IMAGE:$DOCKER_TAG; fi
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push $DOCKER_IMAGE:$DOCKER_TAG
-  - docker push $DOCKER_IMAGE:latest
+  - if $TAG_LATEST ; then docker push $DOCKER_IMAGE:latest; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 ENV KUBE_LATEST_VERSION="v1.16.2"
 # Note: Latest version of helm may be found at:
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.16.1"
+ENV HELM_VERSION="v2.17.0"
 
 RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [2.17.0](https://github.com/dtzar/helm-kubectl/releases/tag/2.16.1) - helm v2.17.0, kubectl v1.16.2, alpine 3.10
 * [2.16.1](https://github.com/dtzar/helm-kubectl/releases/tag/2.16.1) - helm v2.16.1, kubectl v1.16.2, alpine 3.10
 * [2.16.0](https://github.com/dtzar/helm-kubectl/releases/tag/2.16.0) - helm v2.16.0, kubectl v1.16.2, alpine 3.10
 * [2.15.2](https://github.com/dtzar/helm-kubectl/releases/tag/2.15.2) - helm v2.15.2, kubectl v1.16.2, alpine 3.10


### PR DESCRIPTION
hey @dtzar, thank you for this one :)

https://helm.sh/blog/new-location-stable-incubator-charts/
As of new stable repo location, it is recommended to update to helm 2.17.0

