### PR TITLE
helm 3.4.2, kubectl 1.20.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ sudo: required
 
 env:
   DOCKER_IMAGE=dtzar/helm-kubectl
-  DOCKER_TAG=2.17.0
-  TAG_LATEST=false
+  DOCKER_TAG=3.4.2
+  DOCKER_TAG_MAJOR=3
+  TAG_LATEST=true
 
 services:
   - docker
@@ -11,8 +12,10 @@ services:
 script:
   - docker build --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $DOCKER_IMAGE:$DOCKER_TAG .
   - if $TAG_LATEST ; then docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest; fi
+  - docker tag $DOCKER_IMAGE:$DOCKER_TAG_MAJOR
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - docker push $DOCKER_IMAGE:$DOCKER_TAG
+  - docker push $DOCKER_IMAGE:$DOCKER_TAG_MAJOR
   - if $TAG_LATEST ; then docker push $DOCKER_IMAGE:latest; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 script:
   - docker build --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $DOCKER_IMAGE:$DOCKER_TAG .
   - if $TAG_LATEST ; then docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest; fi
-  - docker tag $DOCKER_IMAGE:$DOCKER_TAG_MAJOR
+  - docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:$DOCKER_TAG_MAJOR
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-ENV KUBE_LATEST_VERSION="v1.19.4"
+ENV KUBE_LATEST_VERSION="v1.20.1"
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v2.17.0"
+ENV HELM_VERSION="v3.4.2"
 
 RUN apk add --no-cache ca-certificates bash git openssh curl \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.4.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.2) - helm v3.4.2, kubectl v1.20.1, alpine 3.12
 * [3.4.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.1) - helm v3.4.1, kubectl v1.19.4, alpine 3.12
 * [3.4.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.0) - helm v3.4.0, kubectl v1.19.3, alpine 3.12
 * [3.3.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.3.4) - helm v3.3.4, kubectl v1.19.2, alpine 3.12


### PR DESCRIPTION
Also Closes #46 by adding **DOCKER_TAG_MAJOR** version "3" tag.  Once we have the next 2.x released, someone can add the "2" one.