### PR TITLE
Refactoring of CI process and Dockerfile. Added support for Helm 3.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,29 @@ os: linux
 language: shell
 
 env:
+  VCS_REF=`git rev-parse --short HEAD`
+  BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
   DOCKER_IMAGE=dtzar/helm-kubectl
-  DOCKER_TAG=3.5.0
   DOCKER_TAG_MAJOR=3
   TAG_LATEST=true
+  DOCKER_TAG=3.5.1
+  KUBE_VERSION=1.20.2
 
 services:
   - docker
 
 script:
-  - docker build --build-arg VCS_REF=`git rev-parse --short HEAD` --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` -t $DOCKER_IMAGE:$DOCKER_TAG .
+  # Base Docker Image
+  - | 
+    docker build --build-arg VCS_REF=$VCS_REF \
+                 --build-arg BUILD_DATE=$BUILD_DATE \
+                 --build-arg KUBE_VERSION=$KUBE_VERSION \
+                 --build-arg HELM_VERSION=$DOCKER_TAG \
+                 -t $DOCKER_IMAGE:$DOCKER_TAG .
+  # Build LATEST tag if enabled
   - if $TAG_LATEST ; then docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:latest; fi
+  
+  # Build major version tag
   - docker tag $DOCKER_IMAGE:$DOCKER_TAG $DOCKER_IMAGE:$DOCKER_TAG_MAJOR
 
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:3
 
 ARG VCS_REF
 ARG BUILD_DATE
+ARG KUBE_VERSION
+ARG HELM_VERSION
 
 # Metadata
 LABEL org.label-schema.vcs-ref=$VCS_REF \
@@ -10,17 +12,10 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/dtzar/helm-kubectl" \
       org.label-schema.build-date=$BUILD_DATE
 
-# Note: Latest version of kubectl may be found at:
-# https://github.com/kubernetes/kubernetes/releases
-ENV KUBE_LATEST_VERSION="v1.20.2"
-# Note: Latest version of helm may be found at
-# https://github.com/kubernetes/helm/releases
-ENV HELM_VERSION="v3.5.0"
-
 RUN apk add --no-cache ca-certificates bash git openssh curl \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
-    && wget -q https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm \
     && chmod g+rwx /root \
     && mkdir /config \

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,23 @@ default: docker_build
 
 DOCKER_IMAGE ?= dtzar/helm-kubectl
 DOCKER_TAG ?= `git rev-parse --abbrev-ref HEAD`
+VCS_REF ?= `git rev-parse --short HEAD`
+BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+
+# Note: Latest version of kubectl may be found at:
+# https://github.com/kubernetes/kubernetes/releases
+KUBE_VERSION = "1.20.2"
+
+# Note: Latest version of helm may be found at
+# https://github.com/kubernetes/helm/releases
+HELM_VERSION = "3.5.1"
 
 docker_build:
 	@docker build \
-	  --build-arg VCS_REF=`git rev-parse --short HEAD` \
-	  --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
+	  --build-arg VCS_REF=$(VCS_REF) \
+	  --build-arg BUILD_DATE=$(BUILD_DATE) \
+	  --build-arg KUBE_VERSION=$(KUBE_VERSION) \
+	  --build-arg HELM_VERSION=$(HELM_VERSION) \
 	  -t $(DOCKER_IMAGE):$(DOCKER_TAG) .
 	  
 docker_push:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.5.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.1) - helm v3.5.1, kubectl v1.20.2, alpine 3.13
 * [3.5.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.0) - helm v3.5.0, kubectl v1.20.2, alpine 3.12
 * [3.4.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.2) - helm v3.4.2, kubectl v1.20.1, alpine 3.12
 * [3.4.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.4.1) - helm v3.4.1, kubectl v1.19.4, alpine 3.12


### PR DESCRIPTION
* Added support for Helm 3.5.1
* Refactored the Makefile to use build-args for everything.
* Refactored the travis-ci yaml to use build-args for everything.

With the new setup, you no longer need to update the Dockerfile for a new release. Updating the travis-ci file and the README is all needed.