### PR TITLE
Add jq and bind-tools to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/dtzar/helm-kubectl" \
       org.label-schema.build-date=$BUILD_DATE
 
-RUN apk add --no-cache ca-certificates bash git openssh curl \
+RUN apk add --no-cache ca-certificates bash git openssh curl jq bind-tools \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \


### PR DESCRIPTION
* Add jq for json processing
* Add bind-tools for better DNS support in Docker/k8s environments.

Each package is 500-600KB installed. Total of 1MB in image size increase.

Fixes #35 