### PR TITLE
chore(library): add gettext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/dtzar/helm-kubectl" \
       org.label-schema.build-date=$BUILD_DATE
 
-RUN apk add --no-cache ca-certificates bash git openssh curl jq bind-tools \
+RUN apk add --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \


### PR DESCRIPTION
because `envsubst` is very useful in certain scenarios.

e.g:

```yaml
# helm/values.yaml file
configmap:
    MYSQL_USERNAME: ${MYSQL_USERNAME}
```

```shell
export MYSQL_USERNAME=root

export VALUES=`envsubst < helm/values.yaml`
echo $VALUES > helm/values.yaml

cat helm/values.yaml
# => configmap:
# =>     MYSQL_USERNAME: root
```