### PR TITLE
Support for Helm 3.5.4 and k8s 1.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   DOCKER_IMAGE=dtzar/helm-kubectl
   DOCKER_TAG_MAJOR=3
   TAG_LATEST=true
-  DOCKER_TAG=3.5.3
-  KUBE_VERSION=1.20.4
+  DOCKER_TAG=3.5.4
+  KUBE_VERSION=1.21.0
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-KUBE_VERSION = "1.20.4"
+KUBE_VERSION = "1.21.0"
 
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.5.3"
+HELM_VERSION = "3.5.4"
 
 docker_build:
 	@docker build \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.5.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.4) - helm v3.5.4, kubectl v1.21.0, alpine 3.14
 * [3.5.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.3) - helm v3.5.3, kubectl v1.20.4, alpine 3.13
 * [3.5.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.2) - helm v3.5.2, kubectl v1.20.2, alpine 3.13
 * [3.5.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.5.1) - helm v3.5.1, kubectl v1.20.2, alpine 3.13


### PR DESCRIPTION
* Support for Helm 3.5.4
* Support for k8s 1.21.0

Do not merge until Helm releases 3.5.4 (schedule for 04/14) (Helm [Releases](https://github.com/helm/helm/releases))
Note: Merge #82 before merging this PR.