### PR TITLE
WIP: Support for Helm 3.6.4 and k8s 1.21.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   DOCKER_IMAGE=dtzar/helm-kubectl
   DOCKER_TAG_MAJOR=3
   TAG_LATEST=true
-  DOCKER_TAG=3.6.3
-  KUBE_VERSION=1.21.2
+  DOCKER_TAG=3.6.4
+  KUBE_VERSION=1.21.4
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,11 @@ RUN apk -U upgrade \
     && apk add --upgrade --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/v1.21.4/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-v3.6.4-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/kubectl \
     && mkdir /config \
-    && chmod g+rwx /config /root \
+    && chmod g+rwx /config \
+    && chmod g+rxw /root \
     && helm repo add "stable" "https://charts.helm.sh/stable" --force-update
 
 WORKDIR /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,13 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/dtzar/helm-kubectl" \
       org.label-schema.build-date=$BUILD_DATE
 
-RUN apk add --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl \
-    && wget -q https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
-    && chmod +x /usr/local/bin/helm \
-    && chmod g+rwx /root \
+RUN apk -U upgrade \
+    && apk add --upgrade --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
+    && wget -q https://storage.googleapis.com/kubernetes-release/release/v1.21.4/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://get.helm.sh/helm-v3.6.4-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
+    && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl \
     && mkdir /config \
-    && chmod g+rwx /config \
+    && chmod g+rwx /config /root \
     && helm repo add "stable" "https://charts.helm.sh/stable" --force-update
 
 WORKDIR /config

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-KUBE_VERSION = "1.21.2"
+KUBE_VERSION = "1.21.4"
 
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.6.3"
+HELM_VERSION = "3.6.4"
 
 docker_build:
 	@docker build \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.6.4](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.4) - helm v3.6.4, kubectl v1.21.4, alpine 3.14
 * [3.6.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.3) - helm v3.6.3, kubectl v1.21.2, alpine 3.14
 * [3.6.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.2) - helm v3.6.2, kubectl v1.21.2, alpine 3.14
 * [3.6.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.0) - helm v3.6.0, kubectl v1.21.1, alpine 3.14


### PR DESCRIPTION
**Do not merge until 3.6.4 is released (Scheduled this week).**

* Added support for Helm 3.6.4 scheduled to be released this week
* Added support for k8s 1.21.4
* Added `apk -U upgrade` to update all base alpine system packages.