### PR TITLE
Support for Helm 3.7.0 and k8s 1.22.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
   DOCKER_IMAGE=dtzar/helm-kubectl
   DOCKER_TAG_MAJOR=3
   TAG_LATEST=true
-  DOCKER_TAG=3.6.3
-  KUBE_VERSION=1.21.2
+  DOCKER_TAG=3.7.0
+  KUBE_VERSION=1.22.2
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ LABEL org.label-schema.vcs-ref=$VCS_REF \
       org.label-schema.vcs-url="https://github.com/dtzar/helm-kubectl" \
       org.label-schema.build-date=$BUILD_DATE
 
-RUN apk add --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
-    && wget -q https://storage.googleapis.com/kubernetes-release/release/v1.21.2/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+RUN apk -U upgrade && \
+    apk add --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
+    && wget -q https://storage.googleapis.com/kubernetes-release/release/v1.22.2/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl \
+    && wget -q https://get.helm.sh/helm-v3.7.0-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/kubectl \
-    && wget -q https://get.helm.sh/helm-v3.6.3-linux-amd64.tar.gz -O - | tar -xzO linux-amd64/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm \
     && chmod g+rwx /root \
     && mkdir /config \

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ BUILD_DATE ?= `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-KUBE_VERSION = "1.21.2"
+KUBE_VERSION = "1.22.2"
 
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.6.3"
+HELM_VERSION = "3.7.0"
 
 docker_build:
 	@docker build \

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Supported tags and release links
 
+* [3.7.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.0) - helm v3.7.0, kubectl v1.21.2, alpine 3.14
 * [3.6.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.3) - helm v3.6.3, kubectl v1.21.2, alpine 3.14
 * [3.6.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.2) - helm v3.6.2, kubectl v1.21.2, alpine 3.14
 * [3.6.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.0) - helm v3.6.0, kubectl v1.21.1, alpine 3.14

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Supported tags and release links
 
-* [3.7.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.0) - helm v3.7.0, kubectl v1.21.2, alpine 3.14
+* [3.7.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.0) - helm v3.7.0, kubectl v1.22.2, alpine 3.14
 * [3.6.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.3) - helm v3.6.3, kubectl v1.21.2, alpine 3.14
 * [3.6.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.2) - helm v3.6.2, kubectl v1.21.2, alpine 3.14
 * [3.6.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.0) - helm v3.6.0, kubectl v1.21.1, alpine 3.14


### PR DESCRIPTION
* Support for Helm 3.7.0 released today
* Support for latest k8s 1.22.2
* Added apk upgrade to take care of any last minute Alpine updates