### PR TITLE
Update latest tag on changes to default branch

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -26,6 +26,7 @@ jobs:
           images: |
             dtzar/helm-kubectl
           tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}


### PR DESCRIPTION
* Adds support for updating the `:latest` docker image tag on changes to the default branch (main).