### PR TITLE
Support for ghcr.io container registry

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -25,6 +25,7 @@ jobs:
         with:
           images: |
             dtzar/helm-kubectl
+            ghcr.io/dtzar/helm-kubectl
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -44,6 +45,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         uses: docker/build-push-action@v2


### PR DESCRIPTION
* Support for pushing `dtzar/helm-kubectl` to Github's Container Registry (ghcr.io).

Instructions for creating a ghcr.io token are here: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry