### PR TITLE
Add support for Helm 3.7.1

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -54,6 +54,6 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
           build-args: |
             KUBE_VERSION=1.22.2
-            HELM_VERSION=3.7.0
+            HELM_VERSION=3.7.1
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ KUBE_VERSION = "1.22.2"
 
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.7.0"
+HELM_VERSION = "3.7.1"
 
 docker_build:
 	@docker buildx build \

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 [![ci](https://github.com/dtzar/helm-kubectl/actions/workflows/image-build-push.yaml/badge.svg)](https://github.com/dtzar/helm-kubectl/actions/workflows/image-build-push.yaml)
 [![Docker Stars](https://img.shields.io/docker/stars/dtzar/helm-kubectl.svg?style=flat)](https://hub.docker.com/r/dtzar/helm-kubectl/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dtzar/helm-kubectl.svg)]()
+[![Docker Pulls](https://img.shields.io/docker/pulls/dtzar/helm-kubectl.svg?style=flat)](https://hub.docker.com/r/dtzar/helm-kubectl/)
 
 Supported tags and release links
 
+* [3.7.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.1) - helm v3.7.1, kubectl v1.22.2, alpine 3.14
 * [3.7.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.0) - helm v3.7.0, kubectl v1.22.2, alpine 3.14
 * [3.6.3](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.3) - helm v3.6.3, kubectl v1.21.2, alpine 3.14
 * [3.6.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.6.2) - helm v3.6.2, kubectl v1.21.2, alpine 3.14
@@ -56,7 +57,3 @@ The -v maps your host docker machine Kubernetes configuration directory (~/.kube
 
 For doing a manual local build of the image:  
 `make docker_build`
-
-This image is now fully automated via travisci.org.  
-For reference this .travis.yml file can be validated via:  
-`docker run --rm -it -v yourclonedreporoot:/project caktux/travis-cli lint ./travis.yml`


### PR DESCRIPTION
* Updates Helm to 3.7.1 released today. https://github.com/helm/helm/releases/tag/v3.7.1
* Adds link-ref to one of the README badges.
* Removes reference to travis-ci file.