### PR TITLE
Support for Helm 3.8.1 and k8s 1.23.4

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -62,7 +62,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
           build-args: |
-            KUBE_VERSION=1.23.2
-            HELM_VERSION=3.8.0
+            KUBE_VERSION=1.23.4
+            HELM_VERSION=3.8.1
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN apk -U upgrade \
-    && apk add --no-cache ca-certificates bash git openssh curl gettext jq bind-tools \
+    && apk add --no-cache ca-certificates bash git openssh curl gettext jq \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -O - | tar -xzO ${TARGETOS}-${TARGETARCH}/helm > /usr/local/bin/helm \
     && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl \

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@ DOCKER_TAG ?= `git rev-parse --abbrev-ref HEAD`
 
 # Note: Latest version of kubectl may be found at:
 # https://github.com/kubernetes/kubernetes/releases
-KUBE_VERSION = "1.23.2"
+KUBE_VERSION = "1.23.4"
 
 # Note: Latest version of helm may be found at
 # https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.8.0"
+HELM_VERSION = "3.8.1"
 
 docker_build:
 	@docker buildx build \

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Supported tags and release links
 
+* [3.8.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.8.1) - helm v3.8.1, kubectl v1.23.4, alpine 3.15
 * [3.8.0](https://github.com/dtzar/helm-kubectl/releases/tag/3.8.0) - helm v3.8.0, kubectl v1.23.2, alpine 3.15
 * [3.7.2](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.2) - helm v3.7.2, kubectl v1.23.0, alpine 3.15
 * [3.7.1](https://github.com/dtzar/helm-kubectl/releases/tag/3.7.1) - helm v3.7.1, kubectl v1.22.2, alpine 3.14


### PR DESCRIPTION
* Upgrade Helm to 3.8.1
* Upgrade k8s to 1.23.4
* Remove bind-tools, since it's not really needed.