### PR TITLE
Support for adding image tag with Helm/Kubectl plugins

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -1,4 +1,4 @@
-name: ci
+name: Docker Build
 
 on:
   push:
@@ -66,3 +66,12 @@ jobs:
             HELM_VERSION=3.8.1
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Repository Dispatch
+        if: github.event_name != 'pull_request'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: dtzar/helm-kubectl
+          event-type: image-with-plugins
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/plugins-image.yaml
+++ b/.github/workflows/plugins-image.yaml
@@ -1,0 +1,57 @@
+name: Docker Build
+
+on:
+  repository_dispatch:
+    types: [image-with-plugins]
+
+jobs:
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            dtzar/helm-kubectl
+            ghcr.io/dtzar/helm-kubectl
+          tags: |
+            type=raw,value=plugins,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+      - 
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.plugins
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
+          build-args: |
+            KUBE_VERSION=1.23.4
+            HELM_VERSION=3.8.1
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.plugins
+++ b/Dockerfile.plugins
@@ -1,0 +1,6 @@
+ARG BUILDPLATFORM
+ARG REGISTRY_URL
+ARG IMAGE_TAG
+FROM ${BUILDPLATFORM}dtzar/helm-kubectl:
+
+RUN helm plugin install https://github.com/chartmuseum/helm-push


### PR DESCRIPTION
* Support for using repository dispatch action to trigger a second build once the main image is created. The new image will will include useful/popular Helm/Kubectl plugins.

TODO:

- [ ] Add a personal token `REPO_ACCESS_TOKEN` for repository dispatch to work. it can't be done using `GITHUB_SECRETS`.
- [ ] Add login for generating semver tags with `-plugins` appended.
- [ ] Add logic for passing image tag and repository to `Dockerfile.plugins` 
- [ ] Pass `KUBE_VERSION`, and `HELM_VERSION` via `client-playload`.

For the image tags, what I have in mind is the following:

```
dtzar/helm-kubectl:latest-plugins
dtzar/helm-kubectl:main-plugins
dtzar/helm-kubectl:3-plugins
dtzar/helm-kubectl:3.8-plugins
dtzar/helm-kubectl:3.8.1-plugins
```

Fixes #74 