### PR TITLE
Consolidate versions into an env file. Add support for yq

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,3 @@
-# Note: Latest version of kubectl may be found at: https://github.com/kubernetes/kubernetes/releases
 KUBE_VERSION=1.23.5
-
-# Note: Latest version of helm may be found at: https://github.com/kubernetes/helm/releases
 HELM_VERSION=3.8.2
-
-# Note: Latest version of yq may be found at: https://github.com/mikefarah/yq/releases
 YQ_VERSION=4.24.5

--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Note: Latest version of kubectl may be found at: https://github.com/kubernetes/kubernetes/releases
+KUBE_VERSION=1.23.5
+
+# Note: Latest version of helm may be found at: https://github.com/kubernetes/helm/releases
+HELM_VERSION=3.8.2
+
+# Note: Latest version of yq may be found at: https://github.com/mikefarah/yq/releases
+YQ_VERSION=4.24.5

--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -18,6 +18,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      - 
+        name: Read environment file
+        run: cat .env >> ${GITHUB_ENV}
       -
         name: Docker meta
         id: meta
@@ -62,7 +65,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386,linux/ppc64le,linux/s390x
           build-args: |
-            KUBE_VERSION=1.23.5
-            HELM_VERSION=3.8.2
+            KUBE_VERSION=${{ env.KUBE_VERSION }}
+            HELM_VERSION=${{ env.HELM_VERSION }}
+            YQ_VERSION=${{ env.YQ_VERSION }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,18 @@ ARG KUBE_VERSION
 ARG HELM_VERSION
 ARG TARGETOS
 ARG TARGETARCH
+ARG YQ_VERSION
 
 RUN apk -U upgrade \
     && apk add --no-cache ca-certificates bash git openssh curl gettext jq \
     && wget -q https://storage.googleapis.com/kubernetes-release/release/v${KUBE_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl -O /usr/local/bin/kubectl \
     && wget -q https://get.helm.sh/helm-v${HELM_VERSION}-${TARGETOS}-${TARGETARCH}.tar.gz -O - | tar -xzO ${TARGETOS}-${TARGETARCH}/helm > /usr/local/bin/helm \
-    && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl \
+    && wget -q https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_${TARGETOS}_${TARGETARCH} -O /usr/local/bin/yq \
+    && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl /usr/local/bin/yq \
     && mkdir /config \
     && chmod g+rwx /config /root \
     && helm repo add "stable" "https://charts.helm.sh/stable" --force-update \
-    && kubectl version --client \
+    && kubectl version --client .\
     && helm version
 
 WORKDIR /config

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 default: docker_build
 include .env
 
+# Note: 
+#	Latest version of kubectl may be found at: https://github.com/kubernetes/kubernetes/releases
+# 	Latest version of helm may be found at: https://github.com/kubernetes/helm/releases
+# 	Latest version of yq may be found at: https://github.com/mikefarah/yq/releases
 VARS:=$(shell sed -ne 's/ *\#.*$$//; /./ s/=.*$$// p' .env )
 $(foreach v,$(VARS),$(eval $(shell echo export $(v)="$($(v))")))
 DOCKER_IMAGE ?= dtzar/helm-kubectl

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
 default: docker_build
+include .env
 
+VARS:=$(shell sed -ne 's/ *\#.*$$//; /./ s/=.*$$// p' .env )
+$(foreach v,$(VARS),$(eval $(shell echo export $(v)="$($(v))")))
 DOCKER_IMAGE ?= dtzar/helm-kubectl
 DOCKER_TAG ?= `git rev-parse --abbrev-ref HEAD`
-
-# Note: Latest version of kubectl may be found at:
-# https://github.com/kubernetes/kubernetes/releases
-KUBE_VERSION = "1.23.5"
-
-# Note: Latest version of helm may be found at
-# https://github.com/kubernetes/helm/releases
-HELM_VERSION = "3.8.2"
 
 docker_build:
 	@docker buildx build \


### PR DESCRIPTION
* Consolidate versions in an .env file
* Add support for `yq` cli tool, heavily used when handling YAML files.
* Add support for using .env file during Github Actions.

In the future we would only need to update the `.env` and `README.md` files for each release.