### PR TITLE
Remove adding of Helm stable chart repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN apk -U upgrade \
     && chmod +x /usr/local/bin/helm /usr/local/bin/kubectl /usr/local/bin/yq \
     && mkdir /config \
     && chmod g+rwx /config /root \
-    && helm repo add "stable" "https://charts.helm.sh/stable" --force-update \
     && kubectl version --client \
     && helm version
 


### PR DESCRIPTION
While working on #168 I spotted that https://charts.helm.sh/stable is added by default as repository to this image. Given that support has ended almost 4 years ago (see https://github.com/helm/charts/blob/master/README.md#deprecation-timeline) I think it is best to remove this from the current image.